### PR TITLE
Check OS

### DIFF
--- a/scripts/after_plugin_add.js
+++ b/scripts/after_plugin_add.js
@@ -2,6 +2,7 @@
 
 var iosHelper = require("./lib/ios-helper");
 var utilities = require("./lib/utilities");
+var os = require('os');
 
 module.exports = function(context) {
 
@@ -9,7 +10,7 @@ module.exports = function(context) {
 
     // Add a build phase which runs a shell script that executes the Crashlytics
     // run command line tool which uploads the debug symbols at build time.
-    if (platforms.indexOf("ios") !== -1) {
+    if (platforms.indexOf("ios") !== -1 && os.platform() === 'darwin') {
         var xcodeProjectPath = utilities.getXcodeProjectPath(context);
         iosHelper.removeShellScriptBuildPhase(context, xcodeProjectPath);
         iosHelper.addShellScriptBuildPhase(context, xcodeProjectPath);

--- a/scripts/before_plugin_rm.js
+++ b/scripts/before_plugin_rm.js
@@ -2,13 +2,14 @@
 
 var iosHelper = require("./lib/ios-helper");
 var utilities = require("./lib/utilities");
+var os = require('os');
 
 module.exports = function(context) {
 
     var platforms = context.opts.cordova.platforms;
 
     // Remove the build script that was added when the plugin was installed.
-    if (platforms.indexOf("ios") !== -1) {
+    if (platforms.indexOf("ios") !== -1 && os.platform() === 'darwin') {
         var xcodeProjectPath = utilities.getXcodeProjectPath(context);
         iosHelper.removeShellScriptBuildPhase(context, xcodeProjectPath);
     }


### PR DESCRIPTION
Before adding or removing the plugin for iOS is necessary to check if the OS is OSX, otherwise it crashes when the hook executes.