### PR TITLE
Remove empty spec version which breaks cordova-ios@5

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -68,7 +68,7 @@
 
     <framework src="Fabric" type="podspec" spec="~> 1.7.6"/>
     <framework src="Crashlytics" type="podspec" spec="~> 3.10.1"/>
-    <framework src="Firebase/Core" type="podspec" spec=""/>
+    <framework src="Firebase/Core" type="podspec"/>
 
     <header-file src="src/ios/FirebaseCrashlyticsPlugin.h"/>
     <source-file src="src/ios/FirebaseCrashlyticsPlugin.m"/>


### PR DESCRIPTION
Cordova-ios v5 introduced changes in plugin.xml parsing.
Unfortunatelly it creates malformed Podfile when spec attribute is empty (`spec=""`)

More info here: https://github.com/apache/cordova-ios/pull/577

## Proposed Changes
Remove empty tag
