### PR TITLE
Update to latest depedendencies

### DIFF
--- a/firebase-crashlytics.gradle
+++ b/firebase-crashlytics.gradle
@@ -3,13 +3,13 @@ buildscript {
         maven {
            url 'https://maven.fabric.io/public'
         }
-        maven { url 'https://maven.google.com' }
+        google()
         jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.25.1'
-        classpath 'com.google.gms:google-services:4.0.0'
+        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'io.fabric.tools:gradle:1.28.0'
     }
 }
 
@@ -22,7 +22,7 @@ repositories {
 apply plugin: com.crashlytics.tools.gradle.CrashlyticsPlugin
 
 dependencies {
-    compile('com.crashlytics.sdk.android:crashlytics:2.9.1@aar') {
+    api ('com.crashlytics.sdk.android:crashlytics:2.9.9@aar') {
        transitive = true
     }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
 
     <preference name="ANDROID_FIREBASE_CORE_VERSION" default="16.0.0"/>
     <framework src="com.google.firebase:firebase-core:$ANDROID_FIREBASE_CORE_VERSION"/>
-    <framework src="org.json:json:20171018"/>
+    <framework src="org.json:json:20180813"/>
     <framework src="firebase-crashlytics.gradle" custom="true" type="gradleReference"/>
 
     <source-file src="src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/FirebaseCrashlyticsPlugin.java" target-dir="src/uk/co/reallysmall/cordova/plugin/firebase/crashlytics"/>
@@ -66,8 +66,8 @@
       </feature>
     </config-file>
 
-    <framework src="Fabric" type="podspec" spec="~> 1.7.6"/>
-    <framework src="Crashlytics" type="podspec" spec="~> 3.10.1"/>
+    <framework src="Fabric" type="podspec" spec="~> 1.9.0"/>
+    <framework src="Crashlytics" type="podspec" spec="~> 3.12.0"/>
     <framework src="Firebase/Core" type="podspec"/>
 
     <header-file src="src/ios/FirebaseCrashlyticsPlugin.h"/>


### PR DESCRIPTION
## Proposed Changes

Updated
- fabric dependencies for android
- fabric dependencies for ios
- org.json:json

However it seems that org.json:json may be removed altogether as when building release I'm getting following error (however build finishes fine):
 ```
foobar\platforms\android\app\build.gradle:273: Error: json defines classes that conflict with classes now provided by Android. Solutions include finding newer versions or alternative libraries that don't have the same problem (for example, for httpclient use HttpUrlConnection or okhttp instead), or repackaging the library using something like jarjar. [DuplicatePlatformClasses]
    implementation "org.json:json:20171018"
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "DuplicatePlatformClasses":
   There are a number of libraries that duplicate not just functionality of
   the Android platform but using the exact same class names as the ones
   provided in Android -- for example the apache http classes. This can lead
   to unexpected crashes.

   To solve this, you need to either find a newer version of the library which
   no longer has this problem, or to repackage the library (and all of its
   dependencies) using something like the jarjar tool, or finally, rewriting
   the code to use different APIs (for example, for http code, consider using
   HttpUrlConnection or a library like okhttp).
```