### PR TITLE
[Android] allow unique error grouping

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,7 +51,7 @@
     <source-file src="src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/SetFloatHandler.java" target-dir="src/uk/co/reallysmall/cordova/plugin/firebase/crashlytics"/>
     <source-file src="src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/SetIntHandler.java" target-dir="src/uk/co/reallysmall/cordova/plugin/firebase/crashlytics"/>
     <source-file src="src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/SetUserIdentifierHandler.java" target-dir="src/uk/co/reallysmall/cordova/plugin/firebase/crashlytics"/>
-
+    <source-file src="src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/LogErrorHandler.java" target-dir="src/uk/co/reallysmall/cordova/plugin/firebase/crashlytics"/>
   </platform>
 
   <platform name="ios">

--- a/src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/FirebaseCrashlyticsPlugin.java
+++ b/src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/FirebaseCrashlyticsPlugin.java
@@ -35,6 +35,7 @@ public class FirebaseCrashlyticsPlugin extends CordovaPlugin {
         handlers.put("setInt", new SetIntHandler());
         handlers.put("logException", new LogExceptionHandler());
         handlers.put("setUserIdentifier", new SetUserIdentifierHandler());
+        handlers.put("logError", new LogErrorHandler());
 
         Log.d(TAG, "Initializing FBCrashlyticsPlugin");
 

--- a/src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/LogErrorHandler.java
+++ b/src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/LogErrorHandler.java
@@ -15,14 +15,14 @@ public class LogErrorHandler implements ActionHandler {
         cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                CustomException exception = null;
+                JavascriptException exception = null;
 
                 try {
                     final String msg = args.getString(0);
                     final JSONArray stl = args.getJSONArray(1);
                     final StackTraceLine[] stackTraceLines = getStackTraceLines(stl);
 
-                    exception = new CustomException(msg, stackTraceLines);
+                    exception = new JavascriptException(msg, stackTraceLines);
                 }
                 catch(JSONException e) {
                     Log.e(FirebaseCrashlyticsPlugin.TAG, "Unable to convert args to Exception object", e);
@@ -49,8 +49,8 @@ public class LogErrorHandler implements ActionHandler {
         return stackTraceLines;
     }
 
-    private static class CustomException extends Exception {
-        public CustomException(String message, StackTraceLine[] stackTraceLines) {
+    private static class JavascriptException extends Exception {
+        public JavascriptException(String message, StackTraceLine[] stackTraceLines) {
             super(message);
             StackTraceElement[] stackTrace = new StackTraceElement[stackTraceLines.length];
             for(int i = 0; i < stackTraceLines.length; i++) {

--- a/src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/LogErrorHandler.java
+++ b/src/android/uk/co/reallysmall/cordova/plugin/firebase/crashlytics/LogErrorHandler.java
@@ -1,0 +1,89 @@
+package uk.co.reallysmall.cordova.plugin.firebase.crashlytics;
+
+import android.util.Log;
+
+import com.crashlytics.android.Crashlytics;
+
+import org.apache.cordova.CordovaInterface;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONException;
+
+public class LogErrorHandler implements ActionHandler {
+    @Override
+    public boolean handle(final JSONArray args, CordovaInterface cordova) {
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                CustomException exception = null;
+
+                try {
+                    final String msg = args.getString(0);
+                    final JSONArray stl = args.getJSONArray(1);
+                    final StackTraceLine[] stackTraceLines = getStackTraceLines(stl);
+
+                    exception = new CustomException(msg, stackTraceLines);
+                }
+                catch(JSONException e) {
+                    Log.e(FirebaseCrashlyticsPlugin.TAG, "Unable to convert args to Exception object", e);
+                }
+
+                if(exception != null) {
+                    Crashlytics.logException(exception);
+                }
+            }
+        });
+
+        return true;
+    }
+
+    private StackTraceLine[] getStackTraceLines(JSONArray array) throws JSONException {
+        final int length = array.length();
+
+        StackTraceLine[] stackTraceLines = new StackTraceLine[length];
+        for(int i = 0; i < length; i ++) {
+            JSONObject json = array.getJSONObject(i);
+            stackTraceLines[i] = StackTraceLine.fromJSONObject(json);
+        }
+
+        return stackTraceLines;
+    }
+
+    private static class CustomException extends Exception {
+        public CustomException(String message, StackTraceLine[] stackTraceLines) {
+            super(message);
+            StackTraceElement[] stackTrace = new StackTraceElement[stackTraceLines.length];
+            for(int i = 0; i < stackTraceLines.length; i++) {
+                stackTrace[i] = new StackTraceElement(
+                    stackTraceLines[i].className,
+                    stackTraceLines[i].functionName,
+                    stackTraceLines[i].fileName,
+                    stackTraceLines[i].lineNumber
+                );
+            }
+
+            setStackTrace(stackTrace);
+        }
+    }
+
+    private static class StackTraceLine {
+        public String className;
+        public String functionName;
+        public String fileName;
+        public int lineNumber;
+
+        private StackTraceLine() {
+        }
+
+        public static StackTraceLine fromJSONObject(JSONObject json) throws JSONException {
+            StackTraceLine sl = new StackTraceLine();
+
+            sl.className = json.optString("className", "<<undefined>>");
+            sl.functionName = json.optString("functionName", "<<undefined>>");
+            sl.fileName = json.getString("fileName");
+            sl.lineNumber = json.getInt("lineNumber");
+
+            return sl;
+        }
+    }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,14 @@ declare namespace FirebaseCrashlytics {
         setFloat(key: string, value: number): void;
         setInt(key: string, value: number): void;
         setUserIdentifier(identifier: string): void;
+        logError(message: string, stackTrace: StackTraceLine[]): void;
+    }
+
+    export interface StackTraceLine {
+        className: string;
+        functionName: string;
+        fileName: string;
+        lineNumber: number;
     }
 }
 

--- a/www/crashlytics.js
+++ b/www/crashlytics.js
@@ -35,7 +35,10 @@ Crashlytics.prototype = {
   },
   setUserIdentifier: function(identifier) {
     exec(null, null, PLUGIN_NAME, 'setUserIdentifier', [identifier]);
-  }
+  },
+  logError: function(message, stackTrace) {
+      exec(null, null, PLUGIN_NAME, 'logError', [message, stackTrace]);
+  },
 };
 
 // Log levels


### PR DESCRIPTION
## Fixes
Using **LogException** results in all javascript Errors being grouped as one issue in the Crashlytics console.

## Proposed Changes
Added new function **LogError**. It requires the error message, and an array of stack trace lines. Using LogError will result in grouping of Crashlytics issue based on:

- App Version
- Javascript class
- Javascript function
- Javascript line number

I purposely choose to abstract the stack trace lines, rather than adding dependency to a javascript library. The consumer of this plugin can choose how to extract javascript stack trace information.