### PR TITLE
updated Cocoapods source URL from CDN

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -70,7 +70,7 @@
 
     <podspec>
       <config>
-        <source url="https://github.com/CocoaPods/Specs.git"/>
+        <source url="https://cdn.cocoapods.org/"/>
       </config>
       <pods use-frameworks="true">
         <pod name="FirebaseCrashlytics"  />


### PR DESCRIPTION
Updated Cocoapods source URL according to the new CDN and long time issue:
apache/cordova-ios#738
The GitHub source is no longer supported (and was breaking the plugin setup). Tested on latest macOS and cordova-ios@6.1.1.